### PR TITLE
add ISO-3166 Country Code map, sneak in a quick breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
 # terraform-null-tzdb
-Terraform module for querying IANA Time Zone Database, with optional online
-database retrieval.
+Terraform module for querying Time Zone names and ISO-3166 Country Codes from
+IANA Time Zone Database, with optional online database retrieval.
 
 # Overview
 The IANA (Internet Assigned Numbers Authority) maintains the authoritative 
 [Time Zone Database](https://www.iana.org/time-zones) (TZDB). This module bundles
-the latest version of the [./zone9170.tab](zone1970.tab) file, which correlates
+the latest version of the [zone9170.tab](./zone1970.tab) file, which correlates
 Time Zone names (ex: America/Los\_Angeles) to associated ISO3166 country codes,
 coordinates of the primary population center in the Time Zone, and any comments
-of the Time Zone in context of the TZDB.
+of the Time Zone in context of the TZDB. The [iso3166.tab](./iso3166.tab) file
+is also bundled, which is an IANA maintained map of ISO-3166 Country Codes to
+their long form human-readable names.
 
 # Usage
-The top level module is used to return a Map representation of the latest version
-of the TZDB as of time of the module publishing. By default, it uses the bundled
-file, which does not require any data lookups or resources, so dependent
-resources deterministically be calculated during a plan.
+## Basic Usage
+The top level module is used to return a Map representations of the ISO-3166
+Country Code lookup table (`output.country_codes`) and a Map representation of
+the latest version of the TZDB (`output.time_zones`) as of time of the module
+publishing. By default, it uses the bundled files, which do not require any data
+lookups or resources, so dependent resources deterministically be calculated
+during a plan.
+
+This is probably the syntax you want.
 ```hcl
 module "tzdb" {
   source  = "robzr/tzdb/null"
@@ -22,9 +29,13 @@ module "tzdb" {
 }
 
 locals {
-  example_lookup = module.tzdb.tzdb["America/Los_Angeles"]
+  example_cc_lookup = module.tzdb.country_codes["US"]
+  #
+  # local.example_cc_lookup = "United States"
 
-  # local.example_lookup = {
+  example_tz_lookup = module.tzdb.time_zones["America/Los_Angeles"]
+  #
+  # local.example_tz_lookup = {
   #   "comments" = "Pacific"
   #   "coordinates" = "+340308-1181434"
   #   "country_codes" = tolist([
@@ -32,12 +43,14 @@ locals {
   #   ])
   # }
 }
+## Online Database Retrieval
 ```
-If the latest (or a specific older) version of TZDB at runtime is necessary,
-there is also functionality to dynamically retrieve the TZDB. Since data lookups
-are used to retrieve it, resource decisions depending on interpreting the module
-output may require multiple Terraform runs (this is common Terraform module
-behavior). Only use this syntax if you need it.
+If a specific older version, or the latest version of TZDB at runtime is
+necessary, there is also functionality to dynamically retrieve the TZDB using an
+http data lookup. Note that any resources whose existence depends on the output
+of a data lookup introduces complications in planning; along with the latency
+introduced with the data lookup on a largely static dataset, this is only
+recommended when needed.
 ```hcl
 module "tzdb" {
   source  = "robzr/tzdb/null"
@@ -48,5 +61,7 @@ module "tzdb" {
 ```
 
 # TODO
-- Add dedicated or submodule for ISO3166 Country Code resolution
-- Add support for rules? (would be complex; does anyone want this?)
+- Add support for parsing and returning rules & zone/rule relationships? This
+  would be complex, and probably not all that useful. Implementing actual
+  time offset resolution is not really feasible in pure Terraform given the
+  complexity of the rules - that should be implemented in a provider.

--- a/iso3166.tab
+++ b/iso3166.tab
@@ -1,0 +1,279 @@
+# ISO 3166 alpha-2 country codes
+#
+# This file is in the public domain, so clarified as of
+# 2009-05-17 by Arthur David Olson.
+#
+# From Paul Eggert (2023-09-06):
+# This file contains a table of two-letter country codes.  Columns are
+# separated by a single tab.  Lines beginning with '#' are comments.
+# All text uses UTF-8 encoding.  The columns of the table are as follows:
+#
+# 1.  ISO 3166-1 alpha-2 country code, current as of
+#     ISO/TC 46 N1108 (2023-04-05).  See: ISO/TC 46 Documents
+#     https://www.iso.org/committee/48750.html?view=documents
+# 2.  The usual English name for the coded region.  This sometimes
+#     departs from ISO-listed names, sometimes so that sorted subsets
+#     of names are useful (e.g., "Samoa (American)" and "Samoa
+#     (western)" rather than "American Samoa" and "Samoa"),
+#     sometimes to avoid confusion among non-experts (e.g.,
+#     "Czech Republic" and "Turkey" rather than "Czechia" and "Türkiye"),
+#     and sometimes to omit needless detail or churn (e.g., "Netherlands"
+#     rather than "Netherlands (the)" or "Netherlands (Kingdom of the)").
+#
+# The table is sorted by country code.
+#
+# This table is intended as an aid for users, to help them select time
+# zone data appropriate for their practical needs.  It is not intended
+# to take or endorse any position on legal or territorial claims.
+#
+#country-
+#code	name of country, territory, area, or subdivision
+AD	Andorra
+AE	United Arab Emirates
+AF	Afghanistan
+AG	Antigua & Barbuda
+AI	Anguilla
+AL	Albania
+AM	Armenia
+AO	Angola
+AQ	Antarctica
+AR	Argentina
+AS	Samoa (American)
+AT	Austria
+AU	Australia
+AW	Aruba
+AX	Åland Islands
+AZ	Azerbaijan
+BA	Bosnia & Herzegovina
+BB	Barbados
+BD	Bangladesh
+BE	Belgium
+BF	Burkina Faso
+BG	Bulgaria
+BH	Bahrain
+BI	Burundi
+BJ	Benin
+BL	St Barthelemy
+BM	Bermuda
+BN	Brunei
+BO	Bolivia
+BQ	Caribbean NL
+BR	Brazil
+BS	Bahamas
+BT	Bhutan
+BV	Bouvet Island
+BW	Botswana
+BY	Belarus
+BZ	Belize
+CA	Canada
+CC	Cocos (Keeling) Islands
+CD	Congo (Dem. Rep.)
+CF	Central African Rep.
+CG	Congo (Rep.)
+CH	Switzerland
+CI	Côte d'Ivoire
+CK	Cook Islands
+CL	Chile
+CM	Cameroon
+CN	China
+CO	Colombia
+CR	Costa Rica
+CU	Cuba
+CV	Cape Verde
+CW	Curaçao
+CX	Christmas Island
+CY	Cyprus
+CZ	Czech Republic
+DE	Germany
+DJ	Djibouti
+DK	Denmark
+DM	Dominica
+DO	Dominican Republic
+DZ	Algeria
+EC	Ecuador
+EE	Estonia
+EG	Egypt
+EH	Western Sahara
+ER	Eritrea
+ES	Spain
+ET	Ethiopia
+FI	Finland
+FJ	Fiji
+FK	Falkland Islands
+FM	Micronesia
+FO	Faroe Islands
+FR	France
+GA	Gabon
+GB	Britain (UK)
+GD	Grenada
+GE	Georgia
+GF	French Guiana
+GG	Guernsey
+GH	Ghana
+GI	Gibraltar
+GL	Greenland
+GM	Gambia
+GN	Guinea
+GP	Guadeloupe
+GQ	Equatorial Guinea
+GR	Greece
+GS	South Georgia & the South Sandwich Islands
+GT	Guatemala
+GU	Guam
+GW	Guinea-Bissau
+GY	Guyana
+HK	Hong Kong
+HM	Heard Island & McDonald Islands
+HN	Honduras
+HR	Croatia
+HT	Haiti
+HU	Hungary
+ID	Indonesia
+IE	Ireland
+IL	Israel
+IM	Isle of Man
+IN	India
+IO	British Indian Ocean Territory
+IQ	Iraq
+IR	Iran
+IS	Iceland
+IT	Italy
+JE	Jersey
+JM	Jamaica
+JO	Jordan
+JP	Japan
+KE	Kenya
+KG	Kyrgyzstan
+KH	Cambodia
+KI	Kiribati
+KM	Comoros
+KN	St Kitts & Nevis
+KP	Korea (North)
+KR	Korea (South)
+KW	Kuwait
+KY	Cayman Islands
+KZ	Kazakhstan
+LA	Laos
+LB	Lebanon
+LC	St Lucia
+LI	Liechtenstein
+LK	Sri Lanka
+LR	Liberia
+LS	Lesotho
+LT	Lithuania
+LU	Luxembourg
+LV	Latvia
+LY	Libya
+MA	Morocco
+MC	Monaco
+MD	Moldova
+ME	Montenegro
+MF	St Martin (French)
+MG	Madagascar
+MH	Marshall Islands
+MK	North Macedonia
+ML	Mali
+MM	Myanmar (Burma)
+MN	Mongolia
+MO	Macau
+MP	Northern Mariana Islands
+MQ	Martinique
+MR	Mauritania
+MS	Montserrat
+MT	Malta
+MU	Mauritius
+MV	Maldives
+MW	Malawi
+MX	Mexico
+MY	Malaysia
+MZ	Mozambique
+NA	Namibia
+NC	New Caledonia
+NE	Niger
+NF	Norfolk Island
+NG	Nigeria
+NI	Nicaragua
+NL	Netherlands
+NO	Norway
+NP	Nepal
+NR	Nauru
+NU	Niue
+NZ	New Zealand
+OM	Oman
+PA	Panama
+PE	Peru
+PF	French Polynesia
+PG	Papua New Guinea
+PH	Philippines
+PK	Pakistan
+PL	Poland
+PM	St Pierre & Miquelon
+PN	Pitcairn
+PR	Puerto Rico
+PS	Palestine
+PT	Portugal
+PW	Palau
+PY	Paraguay
+QA	Qatar
+RE	Réunion
+RO	Romania
+RS	Serbia
+RU	Russia
+RW	Rwanda
+SA	Saudi Arabia
+SB	Solomon Islands
+SC	Seychelles
+SD	Sudan
+SE	Sweden
+SG	Singapore
+SH	St Helena
+SI	Slovenia
+SJ	Svalbard & Jan Mayen
+SK	Slovakia
+SL	Sierra Leone
+SM	San Marino
+SN	Senegal
+SO	Somalia
+SR	Suriname
+SS	South Sudan
+ST	Sao Tome & Principe
+SV	El Salvador
+SX	St Maarten (Dutch)
+SY	Syria
+SZ	Eswatini (Swaziland)
+TC	Turks & Caicos Is
+TD	Chad
+TF	French S. Terr.
+TG	Togo
+TH	Thailand
+TJ	Tajikistan
+TK	Tokelau
+TL	East Timor
+TM	Turkmenistan
+TN	Tunisia
+TO	Tonga
+TR	Turkey
+TT	Trinidad & Tobago
+TV	Tuvalu
+TW	Taiwan
+TZ	Tanzania
+UA	Ukraine
+UG	Uganda
+UM	US minor outlying islands
+US	United States
+UY	Uruguay
+UZ	Uzbekistan
+VA	Vatican City
+VC	St Vincent
+VE	Venezuela
+VG	Virgin Islands (UK)
+VI	Virgin Islands (US)
+VN	Vietnam
+VU	Vanuatu
+WF	Wallis & Futuna
+WS	Samoa (western)
+YE	Yemen
+YT	Mayotte
+ZA	South Africa
+ZM	Zambia
+ZW	Zimbabwe

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,14 @@
-output "tzdb" {
+output "country_codes" {
+  description = "Map object of ISO-3166 table, key is Country Code (ex: US), value is name."
+  value = merge([
+    for country in regexall(
+      "(?m)^(?P<code>[^#\t]+)\t(?P<name>[^\n]*)$",
+      local.iso3166,
+    ) : { (country.code) = country.name }
+  ]...)
+}
+
+output "time_zones" {
   description = "Map object of Time Zone Database, key is Time Zone name (ex: America/Los_Angeles)."
   value = merge([
     for tz in regexall(

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "enable_self_update" {
   description = "Use with caution - for module maintenance, updates zone1970.tab with retrieved version."
 }
 
+variable "iso3166_url" {
+  default     = "https://data.iana.org/time-zones/tzdb-%s/iso3166.tab"
+  description = "URL referencing ISO-3166 country map in in iso3166 tab format (%s == -tzdb_version) (used with var.enable_retrieve)."
+}
+
 variable "tzdb_url" {
   default     = "https://data.iana.org/time-zones/tzdb-%s/zone1970.tab"
   description = "URL referencing TZDB in zone1970 tab format (%s == -tzdb_version) (used with var.enable_retrieve)."


### PR DESCRIPTION
No-one is using this yet, so I'm gonna add a real quick breaking change without bumping major.  The output `tzdb` is now the more meaningful `time_zones`, and is consistent with the new output `country_codes`.  Won't do this again, I promise.